### PR TITLE
Aggregate same frames received on different antennas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pyshark==0.4.5
 pytest==7.1.0
+expiringdict==1.2.1
+iterators==0.0.2

--- a/src/frame_aggregator.py
+++ b/src/frame_aggregator.py
@@ -1,0 +1,36 @@
+from expiringdict import ExpiringDict
+
+
+def frame_aggregator(generator, threshold=3, max_age_seconds=2, max_buffer_size=10000):
+    """
+    Generator that yields combined frames from a generator.
+    If frames are equal, combine into one with multiple rssi and sniff_timestamps.
+    If some threshold of combined frames is reached, yield the combined frame.
+
+    :param generator: generator that yields frames
+    :param threshold: number of frames to combine before yielding
+    :param max_age_seconds: max age of frames in buffer
+    :param max_buffer_size: max number of frames in buffer
+    :return: generator that yields combined frames
+    """
+    buffer = ExpiringDict(max_age_seconds=max_age_seconds, max_len=max_buffer_size)
+    for frame in generator:
+        # Create hash of frame
+        frame_hash = hash(frame)
+        # Check if frame is in buffer
+        if frame_hash in buffer:
+            buffer_frame = buffer.get(frame_hash)
+
+            # Append rssi and sniff_timestamps to buffer_frame
+            buffer_frame.sniff_timestamp.append(frame.sniff_timestamp)
+            buffer_frame.wlan_radio.rssi.append(frame.wlan_radio.rssi)
+
+            # Check if threshold of combined frames is reached
+            if len(buffer_frame.sniff_timestamp) == threshold or len(buffer_frame.wlan_radio.rssi) == threshold:
+                buffer.pop(frame_hash)
+                yield buffer_frame
+        else:
+            # Add frame to buffer
+            frame.sniff_timestamp = [frame.sniff_timestamp]
+            frame.wlan_radio.rssi = [frame.wlan_radio.rssi]
+            buffer[frame_hash] = frame

--- a/src/frame_control_information.py
+++ b/src/frame_control_information.py
@@ -25,3 +25,9 @@ class FrameControlInformation:
                and self.subtype == other.subtype \
                and self.receiver_address == other.receiver_address \
                and self.transmitter_address == other.transmitter_address
+
+    def __key__(self):
+        return self.type, self.subtype, self.receiver_address, self.transmitter_address
+
+    def __hash__(self):
+        return hash(self.__key__())

--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,14 @@
 import pyshark
 
+from src.packet_filter import PacketFilter
 from src.wifi_frame import WifiFrame
 
 if __name__ == '__main__':
-    # Only used for testing purposes for now
-    capture = pyshark.LiveCapture(interface='Wi-Fi', monitor_mode=True)
+    # Only used for debugging/manual testing purposes for now
+    capture = pyshark.FileCapture(input_file="../wifi_data")
+    # capture = pyshark.LiveCapture(interface='Wi-Fi', monitor_mode=True)
     capture.set_debug()
 
-    for packet in capture:
-        print(WifiFrame(packet))
-        break
+    for packet in PacketFilter().filter(WifiFrame.construct_from_iterator(capture)):
+        print(packet)
 

--- a/src/packet_filter.py
+++ b/src/packet_filter.py
@@ -1,0 +1,37 @@
+class PacketFilter:
+    # https://en.wikipedia.org/wiki/802.11_Frame_Types
+    whitelisted_types = [2]
+    whitelisted_subtypes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+    def filter(self, iterator):
+        """
+            Filters the iterator for types/subtypes not in whitelist.
+        :param iterator:
+        :return:
+        """
+        return self.filter_iterator(iterator,
+                                    lambda packet:
+                                       self.filter_packets_by_subtypes(packet, self.whitelisted_subtypes)
+                                       and self.packet_types_filter_func(packet, self.whitelisted_types)
+                                    )
+
+    @staticmethod
+    def filter_iterator(iterator, filter_func):
+        """
+            Filters a packet iterator using a filter function.
+
+        :param iterator:
+        :param filter_func:
+        :return:
+        """
+        for packet in iterator:
+            if filter_func(packet):
+                yield packet
+
+    @staticmethod
+    def packet_types_filter_func(packet, types):
+        return packet.frame_control_information.type in types
+
+    @staticmethod
+    def filter_packets_by_subtypes(packet, subtypes):
+        return packet.frame_control_information.subtype in subtypes

--- a/src/wifi_frame.py
+++ b/src/wifi_frame.py
@@ -47,3 +47,16 @@ class WifiFrame:
     def construct_from_iterator(cls, iterator):
         for frame in iterator:
             yield cls(frame)
+
+    def __key__(self):
+        """
+            Returns a tuple of all attributes that are used for comparison
+            Calls __key__ on the frame_control_information object to avoid getting rssi in the comparison
+        :return:
+        """
+        return self.length, self.frame_control_information, self.wlan_radio.__key__()
+
+    def __hash__(self):
+        return hash(self.__key__())
+
+

--- a/src/wifi_frame.py
+++ b/src/wifi_frame.py
@@ -34,3 +34,8 @@ class WifiFrame:
         :return:
         """
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
+
+    @classmethod
+    def construct_from_iterator(cls, iterator):
+        for frame in iterator:
+            yield cls(frame)

--- a/src/wlan_radio_information.py
+++ b/src/wlan_radio_information.py
@@ -38,8 +38,5 @@ class WlanRadioInformation:
         """
         return self.data_rate, self.radio_timestamp
 
-    def __hash__(self):
-        return hash(self.__key__())
-
 
         

--- a/src/wlan_radio_information.py
+++ b/src/wlan_radio_information.py
@@ -29,4 +29,17 @@ class WlanRadioInformation:
         return self.data_rate == other.data_rate \
             and self.radio_timestamp == other.radio_timestamp
 
+    def __key__(self):
+        """
+            Overrides the default implementation
+            Don't compare RSSI
+        :param other:
+        :return:
+        """
+        return self.data_rate, self.radio_timestamp
+
+    def __hash__(self):
+        return hash(self.__key__())
+
+
         

--- a/src/wlan_radio_information.py
+++ b/src/wlan_radio_information.py
@@ -38,5 +38,8 @@ class WlanRadioInformation:
         """
         return self.data_rate, self.radio_timestamp
 
+    def __hash__(self):
+        return hash(self.__key__())
+
 
         

--- a/test/test_frame_aggregator.py
+++ b/test/test_frame_aggregator.py
@@ -1,0 +1,124 @@
+from time import sleep
+
+from iterators import TimeoutIterator
+
+from src.frame_aggregator import frame_aggregator
+from src.frame_control_information import FrameControlInformation
+from src.wifi_frame import WifiFrame
+from src.wlan_radio_information import WlanRadioInformation
+
+
+def make_wifi_frame(sniff_timestamp, rssi, transmitter_address='00:00:00:00:00:01'):
+    return WifiFrame(
+        length=200,
+        sniff_timestamp=sniff_timestamp,
+        frame_control_information=FrameControlInformation(
+            fc_type=0,
+            subtype=1,
+            receiver_address='00:00:00:00:00:00',
+            transmitter_address=transmitter_address,
+        ),
+        wlan_radio=WlanRadioInformation(
+            rssi=rssi,
+            data_rate=12,
+            radio_timestamp=1200
+        )
+    )
+
+
+def test_frame_aggregator_combine_packets():
+    # Arrange
+    frames = [
+        make_wifi_frame(1, 5),
+        make_wifi_frame(2, 6),
+        make_wifi_frame(3, 7),
+    ]
+
+    # Act
+    combined_frames = list(frame_aggregator(frames, 3, 1, 10))
+
+    # Assert
+    assert len(combined_frames) == 1
+    combined_frame = combined_frames[0]
+    assert len(combined_frame.sniff_timestamp) == 3
+    assert 1 in combined_frame.sniff_timestamp
+    assert 2 in combined_frame.sniff_timestamp
+    assert 3 in combined_frame.sniff_timestamp
+    assert len(combined_frame.wlan_radio.rssi) == 3
+    assert 5 in combined_frame.wlan_radio.rssi
+    assert 6 in combined_frame.wlan_radio.rssi
+    assert 7 in combined_frame.wlan_radio.rssi
+
+    # Rest of the combined frame should be equal to any of the test input frames
+    # as the compare function does not care about rssi or sniff_timestamp
+    assert combined_frame == frames[0]
+
+
+def test_frame_aggregator_does_not_yield_frames_before_threshold_reached():
+    # Arrange
+    frames = [
+        make_wifi_frame(1, 5),
+        make_wifi_frame(2, 6),
+        make_wifi_frame(3, 7),
+    ]
+
+    # Act
+    combined_frames = list(frame_aggregator(frames, 4, 2, 10))
+
+    # Assert
+    assert len(combined_frames) == 0
+
+
+def test_frame_aggregator_frames_expire():
+    """
+        The idea of this test, is to provide the aggregator with enough packets to exceed the threshold,
+        and combine them into a combined frame.
+
+        However the generator is slow (sleeps 0.05 seconds pr frame), such that the aggregator does not see the
+        required frames in time, and therefore drops the combined frame.
+
+        The use case for this, is to automatically disregard old frames, as there will always be a chance for a
+        wifi frame to only reach a subset of the threshold. Without the expiry, the aggregator would never drop
+        the frames from the buffer, essentially creating an ever growing buffer.
+    """
+
+    # Arrange
+    frames = [
+        make_wifi_frame(1, 5),
+        make_wifi_frame(2, 6),
+        make_wifi_frame(3, 7),
+    ]
+
+    def slow_generator(list_of_frames):
+        for frame in list_of_frames:
+            sleep(0.05)
+            yield frame
+
+    # Act
+    combined_frames = list(TimeoutIterator(frame_aggregator(slow_generator(frames), 3, 0.1, 10), 0.2))
+
+    # Assert
+    assert len(combined_frames) == 0
+
+
+def test_frame_aggregator_full_buffer():
+    # Arrange
+    frames = [
+        make_wifi_frame(1, 5),
+        make_wifi_frame(2, 6),
+
+        # Fill the buffer with other frames.
+        make_wifi_frame(4, 5, transmitter_address='00:00:00:00:00:03'),
+        make_wifi_frame(5, 6, transmitter_address='00:00:00:00:00:04'),
+        make_wifi_frame(5, 6, transmitter_address='00:00:00:00:00:05'),
+
+        # This would result in a combined frame, if the first two frames is still in the buffer.
+        make_wifi_frame(3, 7),
+    ]
+
+    # Act
+    combined_frames = list(frame_aggregator(frames, 3, 1, 2))
+
+    # Assert that the first two frames were dropped
+    assert len(combined_frames) == 0
+

--- a/test/test_packet_filter.py
+++ b/test/test_packet_filter.py
@@ -1,0 +1,8 @@
+from src.packet_filter import PacketFilter
+from src.wifi_frame import WifiFrame
+
+
+def test_packet_filter_subtype_allowed():
+    assert PacketFilter.filter_packets_by_subtypes(
+        WifiFrame(), [0]
+    ) is True

--- a/test/test_wifi_frame.py
+++ b/test/test_wifi_frame.py
@@ -1,3 +1,5 @@
+import copy
+
 from src.wifi_frame import WifiFrame
 from test.utils.wifi_test_utils import Frame, Layer
 
@@ -69,6 +71,7 @@ def test_compare_wifi_frame_identical():
     # Assert
     assert wifi_frame1 == wifi_frame2
 
+
 def test_compare_wifi_frame_different_timestamp():
     # Arrange
     frame1 = Frame("340", "1647417907.513663000", {
@@ -105,6 +108,7 @@ def test_compare_wifi_frame_different_timestamp():
     # Assert
     assert wifi_frame1 == wifi_frame2
 
+
 def test_compare_wifi_frame_different_rssi():
     # Arrange
     frame1 = Frame("340", "1647417907.513663000", {
@@ -140,6 +144,7 @@ def test_compare_wifi_frame_different_rssi():
 
     # Assert
     assert wifi_frame1 == wifi_frame2
+
 
 def test_compare_wifi_frame_different():
     # Arrange
@@ -178,3 +183,66 @@ def test_compare_wifi_frame_different():
     assert wifi_frame1 != wifi_frame2
 
 
+def test_wifi_frame_has_same_hash_with_different_rrsi_and_sniff_timestamp():
+    frame1 = WifiFrame.from_frame(Frame("340", "1647417907.513663000", {
+        'wlan': Layer({
+            'wlan.fc.type': '0',
+            'wlan.fc.subtype': '4',
+            'wlan.ra_resolved': '00:0c:29:b7:d9:b0',
+            'wlan.ta_resolved': '00:0c:29:b7:d9:b1',
+        }),
+        'wlan_radio': Layer({
+            'wlan_radio.signal_dbm': '-62',
+            'wlan_radio.data_rate': '54',
+            'wlan_radio.timestamp': '1567757308'
+        })
+    }))
+    # Copy frame 1 and change the rssi and sniff timestamp
+
+    frame2 = copy.deepcopy(frame1)
+    frame2.sniff_timestamp = 1647417905.513663000
+    frame2.wlan_radio.rssi = -63
+
+    assert frame1.__key__() == frame2.__key__()
+    assert hash(frame1) == hash(frame2)
+
+
+def test_wifi_frame_has_same_hash_identical():
+    frame1 = WifiFrame.from_frame(Frame("340", "1647417907.513663000", {
+        'wlan': Layer({
+            'wlan.fc.type': '0',
+            'wlan.fc.subtype': '4',
+            'wlan.ra_resolved': '00:0c:29:b7:d9:b0',
+            'wlan.ta_resolved': '00:0c:29:b7:d9:b1',
+        }),
+        'wlan_radio': Layer({
+            'wlan_radio.signal_dbm': '-62',
+            'wlan_radio.data_rate': '54',
+            'wlan_radio.timestamp': '1567757308'
+        })
+    }))
+    frame2 = copy.deepcopy(frame1)
+
+    assert frame1.__key__() == frame2.__key__()
+    assert hash(frame1) == hash(frame2)
+
+
+def test_wifi_frame_has_different_hash():
+    frame1 = WifiFrame.from_frame(Frame("340", "1647417907.513663000", {
+        'wlan': Layer({
+            'wlan.fc.type': '0',
+            'wlan.fc.subtype': '4',
+            'wlan.ra_resolved': '00:0c:29:b7:d9:b0',
+            'wlan.ta_resolved': '00:0c:29:b7:d9:b1',
+        }),
+        'wlan_radio': Layer({
+            'wlan_radio.signal_dbm': '-62',
+            'wlan_radio.data_rate': '54',
+            'wlan_radio.timestamp': '1567757308'
+        })
+    }))
+    frame2 = copy.deepcopy(frame1)
+    frame2.length = 341
+
+    assert frame1.__key__() != frame2.__key__()
+    assert hash(frame1) != hash(frame2)


### PR DESCRIPTION
Solves #9 

Aggregate frames received within some time period with some buffer size to one combined frame with multiple rssi and sniff_timestamps.

Utilizes [ExpiringDicts](https://github.com/mailgun/expiringdict) to enable expiry time and buffer size limits.
